### PR TITLE
Change seq

### DIFF
--- a/do_full_run.sh
+++ b/do_full_run.sh
@@ -134,9 +134,4 @@ rm -r ./output/202*/database ./output/202*/input
 # WARNING: I/O heavy, saturates SATA3, requires extra temporary space
 sh ./remove_trailing_commas.sh
 
-# Text myself that it's all done
-{ # try
-  curl "https://api.telegram.org/bot${Notify_bot_key}/sendMessage?text=Done%20copying%20all%20files&chat_id=${telegram_chatid}" &&
-} || { # catch
-  echo "Failed to send a confirmation, logging success anyway."
-}
+echo "Successfully completed runs"

--- a/do_full_run.sh
+++ b/do_full_run.sh
@@ -14,7 +14,7 @@ set -o errexit -o noclobber -o pipefail -o nounset
 usage() {
   echo "Usage: sh ./$0 <[options]>
         Options:
-                -n    --batch_size        The number od simulations to run in one batch, strictly integer and positive
+                -n    --batch_size        The number of simulations to run in one batch, strictly integer and positive
                 -p    --population_size   The size of a population, strictly integer and positive
                 -s    --start_year        The year simulation starts, from 2010 to 2023
                 -e    --end_year          The year simulation ends, from 2010 to 2023, greater or equal than \`-s\`

--- a/do_full_run.sh
+++ b/do_full_run.sh
@@ -120,12 +120,13 @@ then
 fi
 
 # Runs 1,000 runs as 50 sequential runs of n=20 with 50 unique starting seeds
-seq 100 100 5000 | parallel java -cp simpaths.jar simpaths.experiment.SimPathsMultiRun -r {} -n $BATCH_SIZE \
-                                                                                             -p $POPULATION_SIZE \
-                                                                                             -s $START_YEAR \
-                                                                                             -e $END_YEAR \
-                                                                                             -g $GUI \
-                                                                                             -f
+parallel java -cp simpaths.jar simpaths.experiment.SimPathsMultiRun -r {} -n $BATCH_SIZE \
+                                                                          -p $POPULATION_SIZE \
+                                                                          -s $START_YEAR \
+                                                                          -e $END_YEAR \
+                                                                          -g $GUI \
+                                                                          -f \
+																		  ::: {100..5000..100}
 
 # Tidy output folders, removing empty database folders and redundant input folders (keeps csvs)
 rm -r ./output/202*/database ./output/202*/input

--- a/do_full_run.sh
+++ b/do_full_run.sh
@@ -120,13 +120,13 @@ then
 fi
 
 # Runs 1,000 runs as 50 sequential runs of n=20 with 50 unique starting seeds
-parallel java -cp simpaths.jar simpaths.experiment.SimPathsMultiRun -r {} -n $BATCH_SIZE \
-                                                                          -p $POPULATION_SIZE \
-                                                                          -s $START_YEAR \
-                                                                          -e $END_YEAR \
-                                                                          -g $GUI \
-                                                                          -f \
-																		  ::: {100..5000..100}
+parallel java -jar simpaths.jar -r {} -n $BATCH_SIZE \
+                                -p $POPULATION_SIZE \
+                                -s $START_YEAR \
+                                -e $END_YEAR \
+                                -g $GUI \
+                                -f \
+								::: {100..5000..100}
 
 # Tidy output folders, removing empty database folders and redundant input folders (keeps csvs)
 rm -r ./output/202*/database ./output/202*/input

--- a/do_full_run.sh
+++ b/do_full_run.sh
@@ -14,7 +14,7 @@ set -o errexit -o noclobber -o pipefail -o nounset
 usage() {
   echo "Usage: sh ./$0 <[options]>
         Options:
-                -n    --batch_size        The number of simulations to run in one batch, strictly integer and positive
+                -b    --batch_size        The number od simulations to run in one batch, strictly integer and positive
                 -p    --population_size   The size of a population, strictly integer and positive
                 -s    --start_year        The year simulation starts, from 2010 to 2023
                 -e    --end_year          The year simulation ends, from 2010 to 2023, greater or equal than \`-s\`
@@ -28,7 +28,7 @@ exit_abnormal() {
 }
 
 # parse input arguments
-VALID_ARGS="$(getopt -o n:p:s:e:g: -l batch_size:,population_size:,start_year:,end_year:,gui: --name "$0" -- "$@")"
+VALID_ARGS="$(getopt -o b:p:s:e:g: -l batch-size:,population:,start_year:,end_year:,gui: --name "$0" -- "$@")"
 
 eval set -- "$VALID_ARGS"
 
@@ -41,7 +41,7 @@ re_isanum='^[0-9]*[1-9][0-9]*$'
 while true
 do
     case "$1" in
-        -n|--batch_size)
+        -b|--batch_size)
             # if $2 not whole:
             if ! [[ $2 =~ $re_isanum ]]
             then
@@ -53,7 +53,7 @@ do
             BATCH_SIZE=$2
             shift 2
             ;;
-        -p|--population_size)
+        -p|--population)
             # if $2 not whole:
             if ! [[ $2 =~ $re_isanum ]]
             then
@@ -103,8 +103,8 @@ do
             shift 2
             ;;
         --)
-            echo "All parameters must be provided" >&2
-            exit_abnormal
+            shift
+            break
             ;;
         *)
             echo "Not implemented: $1" >&2

--- a/do_full_run.sh
+++ b/do_full_run.sh
@@ -126,7 +126,7 @@ parallel java -jar simpaths.jar -r {} -n $BATCH_SIZE \
                                 -e $END_YEAR \
                                 -g $GUI \
                                 -f \
-								::: {100..5000..100}
+                                ::: {100..5000..100}
 
 # Tidy output folders, removing empty database folders and redundant input folders (keeps csvs)
 rm -r ./output/202*/database ./output/202*/input

--- a/do_full_run.sh
+++ b/do_full_run.sh
@@ -14,7 +14,7 @@ set -o errexit -o noclobber -o pipefail -o nounset
 usage() {
   echo "Usage: sh ./$0 <[options]>
         Options:
-                -b    --batch_size        The number od simulations to run in one batch, strictly integer and positive
+                -b    --batch_size        The number of simulations to run in one batch, strictly integer and positive
                 -p    --population_size   The size of a population, strictly integer and positive
                 -s    --start_year        The year simulation starts, from 2010 to 2023
                 -e    --end_year          The year simulation ends, from 2010 to 2023, greater or equal than \`-s\`


### PR DESCRIPTION
Crucially - the Telegram message update only works for me or can be replicated by anyone who wants to set up their own account. Removed as redundant.

Changed sequencing to end of parallel call (which isn't yet tested). Big thing missing here is that this is hard-coded to do 50 parallel runs with the option of how many runs within each. To change number of parallels this would require a re-calculation to pass that many seeds to parallel.