### PR TITLE
added extra checks in sh file

### DIFF
--- a/do_full_run.sh
+++ b/do_full_run.sh
@@ -119,6 +119,23 @@ then
   exit_abnormal
 fi
 
+if ! test -f simpaths.jar
+then
+    echo "This must be run in the same directory as the compiled (with dependencies) \`simpaths.jar\`"
+    exit_abnormal
+fi
+
+if ! test -d input
+then
+    echo "This must be run in the same directory as the \`input/\` folder"
+    exit_abnormal
+fi
+
+if ! test -d output/logs
+then
+    mkdir -p output/logs
+fi
+
 # Runs 1,000 runs as 50 sequential runs of n=20 with 50 unique starting seeds
 seq 100 100 5000 | parallel java -cp simpaths.jar simpaths.experiment.SimPathsMultiRun -r {} -n $BATCH_SIZE \
                                                                                              -p $POPULATION_SIZE \

--- a/do_full_run.sh
+++ b/do_full_run.sh
@@ -137,12 +137,12 @@ then
 fi
 
 # Runs 1,000 runs as 50 sequential runs of n=20 with 50 unique starting seeds
-seq 100 100 5000 | parallel java -cp simpaths.jar simpaths.experiment.SimPathsMultiRun -r {} -n $BATCH_SIZE \
-                                                                                             -p $POPULATION_SIZE \
-                                                                                             -s $START_YEAR \
-                                                                                             -e $END_YEAR \
-                                                                                             -g $GUI \
-                                                                                             -f
+seq 100 100 5000 | parallel java -jar simpaths.jar -r {} -n $BATCH_SIZE \
+                                                   -p $POPULATION_SIZE \
+                                                   -s $START_YEAR \
+                                                   -e $END_YEAR \
+                                                   -g $GUI \
+                                                   -f
 
 # Tidy output folders, removing empty database folders and redundant input folders (keeps csvs)
 rm -r ./output/202*/database ./output/202*/input


### PR DESCRIPTION
Checks for presence of:

- compiled `simpaths.jar`; exits if none
- `input/` folder; exits if none
- `output/logs` folder; creates if missing